### PR TITLE
Use Svg.svg instead of Html.node "svg"

### DIFF
--- a/src/Svg/Types.elm
+++ b/src/Svg/Types.elm
@@ -91,7 +91,7 @@ mapAttribute f attribute =
 
 toHtml : Html msg -> Html.Html msg
 toHtml (HtmlNode tagName attributes children) =
-    Html.node "svg" (List.map attributeToSvg attributes) (List.map svgToSvg children)
+    Svg.svg (List.map attributeToSvg attributes) (List.map svgToSvg children)
 
 
 svgToSvg : Svg msg -> Svg.Svg msg


### PR DESCRIPTION
👋 

Thanks for this package!
I had an issue with the `toHtml` function, this fixes that.

When using `Html.node` the SVG doesn't render when used in a Elm view.
The `Svg.svg` function on the other hand, does render it.